### PR TITLE
add #! to hooks

### DIFF
--- a/test/repo/vim/hooks/post-down/post-down-final.sh
+++ b/test/repo/vim/hooks/post-down/post-down-final.sh
@@ -1,2 +1,2 @@
-
+#!/usr/bin/env sh
 echo "running global vim post-down post-down-final.sh"

--- a/test/repo/vim/hooks/post-up/install_plugins.sh
+++ b/test/repo/vim/hooks/post-up/install_plugins.sh
@@ -1,2 +1,2 @@
-
+#!/usr/bin/env sh
 echo "running post-up install_plugins.sh"

--- a/test/repo/vim/hooks/pre-down/setup.sh
+++ b/test/repo/vim/hooks/pre-down/setup.sh
@@ -1,2 +1,2 @@
-
+#!/usr/bin/env sh
 echo "running global vim pre-down setup.sh"

--- a/test/repo/vim/hooks/pre-up/setup.sh
+++ b/test/repo/vim/hooks/pre-up/setup.sh
@@ -1,2 +1,2 @@
-
+#!/usr/bin/env sh
 echo "running global vim pre-up setup.sh"

--- a/test/repo/vim/hosts/desktop1/hooks/post-down/remove_vim_package.sh
+++ b/test/repo/vim/hosts/desktop1/hooks/post-down/remove_vim_package.sh
@@ -1,2 +1,2 @@
-
+#!/usr/bin/env sh
 echo "desktop1 post-down script running"

--- a/test/repo/vim/hosts/desktop1/hooks/post-up/00-install_plugins.sh
+++ b/test/repo/vim/hosts/desktop1/hooks/post-up/00-install_plugins.sh
@@ -1,2 +1,2 @@
-
+#!/usr/bin/env sh
 echo "running desktop1 00-install_plugins.sh"

--- a/test/repo/vim/hosts/desktop1/hooks/post-up/99-custom_install_after.sh
+++ b/test/repo/vim/hosts/desktop1/hooks/post-up/99-custom_install_after.sh
@@ -1,2 +1,2 @@
-
+#!/usr/bin/env sh
 echo "running desktop1 99-custom_install_after.sh"

--- a/test/repo/vim/hosts/desktop1/hooks/pre-down/setup.sh
+++ b/test/repo/vim/hosts/desktop1/hooks/pre-down/setup.sh
@@ -1,2 +1,2 @@
-
+#!/usr/bin/env sh
 echo "desktop1 pre-down script running"

--- a/test/repo/vim/hosts/desktop1/hooks/pre-up/setup.sh
+++ b/test/repo/vim/hosts/desktop1/hooks/pre-up/setup.sh
@@ -1,2 +1,2 @@
-
+#!/usr/bin/env sh
 echo "desktop1 pre-up script running"

--- a/test/repo/vim/hosts/hook_fail_host/hooks/pre-up/dead_hook.sh
+++ b/test/repo/vim/hosts/hook_fail_host/hooks/pre-up/dead_hook.sh
@@ -1,2 +1,2 @@
-
+#!/usr/bin/env sh
 echo "should not run due to executable bit not set"

--- a/test/repo/vim/hosts/hook_fail_host2/hooks/pre-up/dead_hook.sh
+++ b/test/repo/vim/hosts/hook_fail_host2/hooks/pre-up/dead_hook.sh
@@ -1,3 +1,3 @@
-
+#!/usr/bin/env sh
 echo "returning 1 :P"
 exit 1


### PR DESCRIPTION
As of March 2018, libstd in rustc uses posix_spawn() instead of execlp(), which
means that shell scripts have to have an interpreter. Otherwise execution fails.